### PR TITLE
Bugfix 124 - Creator name/Deadline Text overlap list quiz item

### DIFF
--- a/app/src/main/res/layout/list_item_quizzes.xml
+++ b/app/src/main/res/layout/list_item_quizzes.xml
@@ -107,9 +107,8 @@
             android:layout_marginEnd="@dimen/medium_margin"
             android:text="@string/deadline"
             android:textColor="@color/color_green_deadline"
-            app:layout_constraintBottom_toTopOf="@+id/tv_creator_name"
-            app:layout_constraintEnd_toStartOf="@+id/tv_deadline"
-            app:layout_constraintTop_toBottomOf="@+id/tv_creator_name" />
+            app:layout_constraintBottom_toBottomOf="@+id/tv_completion_status"
+            app:layout_constraintEnd_toStartOf="@+id/tv_deadline"/>
 
         <View
             android:id="@+id/difficulty_hard"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -110,7 +110,7 @@
     <string name="msg_login_successful">Login successful</string>
     <string name="txt_status_completed">Completed</string>
     <string name="txt_status_pending">Not started</string>
-    <string name="txt_deadline_none">DEADLINE NONE</string>
+    <string name="txt_deadline_none">None</string>
 
     //Navigation Drawer Menu Items
     <string name="scoreboard">Scoreboard</string>


### PR DESCRIPTION
<!-- Note: PR should be only in the development branch -->
Fixes #124 

## Description

_A few sentences describing the overall goals of the pull request's commits.
What is the current behavior of the app? What is the updated/expected behavior
with this PR?_
Deadline text was overlapping creator name for Deadline=None. Can also overlap for long creator name.
Made following changes:
1. Changed string "txt_deadline_none" to None
2. Shifted deadline to the line below, as status will be shorter, and creator names can be longer.

## Screenshots

**BEFORE**:
![image](https://user-images.githubusercontent.com/2716159/39761390-990f143e-52f5-11e8-8080-bbde333adcbd.png)

**AFTER**:
![image](https://user-images.githubusercontent.com/2716159/39771812-0cab7af2-5311-11e8-8b5b-7864cc47a696.png)