### PR TITLE
Fixes Landscape Issue #137

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -18,7 +18,9 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme"
         tools:replace="android:allowBackup">
-        <activity android:name=".ui.signin.SignInActivity">
+        <activity android:name=".ui.signin.SignInActivity"
+            android:configChanges="orientation"
+            android:screenOrientation="portrait">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 
@@ -35,7 +37,9 @@
                 <action android:name="android.intent.action.VIEW" />
             </intent-filter>
         </activity>
-        <activity android:name=".ui.profile.UserProfileActivity">
+        <activity android:name=".ui.profile.UserProfileActivity"
+            android:configChanges="orientation"
+            android:screenOrientation="portrait">
 
             <!--
             Adding this intent filter here to silence the warning ,this should be a part of home


### PR DESCRIPTION
<!-- Note: PR should be only in the development branch -->
Fixes #137 

## Description

The Code in App has been added so that Orientation Configuration is taken from Android Framework and set to Portrait for First 2 Screens.
This effectively solves the bug.
Since the base code is same, app will continue to function as it did before.
The PR won't conflict with current branch.


## Screenshots

**BEFORE**: 
![screenshot_20180511-125432](https://user-images.githubusercontent.com/30470730/39913079-50527742-551e-11e8-9a5c-2933bdd55ef5.png)

![screenshot_20180511-125454](https://user-images.githubusercontent.com/30470730/39913091-58994f3e-551e-11e8-9f07-e5ae71d700c2.png)



**AFTER**:
![screenshot_20180511-132005](https://user-images.githubusercontent.com/30470730/39913147-7aa70ddc-551e-11e8-8d35-fd05b35477de.png)

![screenshot_20180511-132136](https://user-images.githubusercontent.com/30470730/39913148-7af0b7ca-551e-11e8-8ed7-a0f2ef5c0c7a.png)



